### PR TITLE
修改navigationViewStyle为Stack修复iPad/Apple Silicon下大部分UI不能正常显示

### DIFF
--- a/BitClient/BitClientApp.swift
+++ b/BitClient/BitClientApp.swift
@@ -99,6 +99,7 @@ struct ContentView: View {
             .navigationBarItems(leading: navigationBarLeadingItems)
             .navigationBarTitle(Text(tabTitle[selectedIndex]), displayMode: .inline)
         }
+        .navigationViewStyle(StackNavigationViewStyle())
         .onChange(of: scenePhase) { newScenePhase in
             switch newScenePhase {
             case .active:


### PR DESCRIPTION
首先感谢开发者优秀的项目

在尝试为iPad / Apple Silicon 编译此App时发现大部分UI不能正常显示

修复前：
<img width="1239" alt="Before" src="https://user-images.githubusercontent.com/41369943/189296319-81fac6ff-9ddb-4359-8ac5-9416e397aa3b.png">


通过增加 `navigationViewStyle` modifier 为 `StackNavigationStyle()`可解决此问题

修复后：
<img width="1234" alt="After" src="https://user-images.githubusercontent.com/41369943/189296752-bd30618b-3f59-4498-add3-79b306b4edac.png">

